### PR TITLE
Fix up logging to prevent logging of binary files

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,6 +16,8 @@
         </encoder>
     </appender>
 
+    <logger name="com.sun.jersey.api.client.filter.LoggingFilter" level="WARN"/>
+
     <root level="info" additivity="false">
         <appender-ref ref="MAVEN"/>
     </root>


### PR DESCRIPTION
Renamed the log config file so that it is picked up by logback and changed the logging level used for the Jersey Client Logging Filter so that it no longer logs whole binary files, previously this would crash a terminal when packaging docker images with large binary files
