### PR TITLE
Copy and filter resources before docker orchestration is done

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.alexecollins.docker</groupId>
             <artifactId>docker-java-orchestration</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.1-SNAPSHOT</version>
         </dependency>
         <!-- plugin -->
         <dependency>


### PR DESCRIPTION
AbstractDockerMojo does the filtering before Orchestrator builds images.
Enviroment variables and system properties are also added to filter properties.
This way enviroment variables can be used for example when configuring volumes in conf.yml.
