### PR TITLE
Allow Docker certificate path to be specified for remote Docker daemon running behind https

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -159,3 +159,39 @@ healthChecks:
 
 This can be turned off by set `exposeContainerIp` to `false` in `conf.yml`
 
+Using with boot2docker
+---
+
+Boot2docker runs docker in a Virtualbox VM and (by default) runs the Docker daemon on HTTPS. It exposes it's configuration via environment variables on the host:
+
+```
+$ boot2docker shellinit
+Writing /Users/auser/.boot2docker/certs/boot2docker-vm/ca.pem
+Writing /Users/auser/.boot2docker/certs/boot2docker-vm/cert.pem
+Writing /Users/auser/.boot2docker/certs/boot2docker-vm/key.pem
+    export DOCKER_HOST=tcp://192.168.59.103:2376
+    export DOCKER_CERT_PATH=/Users/auser/.boot2docker/certs/boot2docker-vm
+    export DOCKER_TLS_VERIFY=1
+```
+
+As the certificates are self-signed, the Docker client needs to be told about the location of the certificates. This can be done by specifying
+the certificatePath in the maven plugin configuration
+
+```xml
+    <plugin>
+        <groupId>com.alexecollins.docker</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>${docker-maven-plugin.version}</version>
+        <configuration>
+            <certificatePath>${env.DOCKER_CERT_PATH}</certificatePath>
+        </configuration>
+        <dependencies>
+            <dependency>
+                <groupId>com.alexecollins.docker</groupId>
+                <artifactId>docker-java-orchestration-plugin-boot2docker</artifactId>
+                <version>${docker-java-orchestration-plugin-boot2docker.version}</version>
+            </dependency>
+        </dependencies>
+    </plugin>
+
+```

--- a/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
+++ b/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
@@ -88,6 +88,12 @@ abstract class AbstractDockerMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", property = "docker.skip")
     private boolean skip;
 
+    /**
+     * Specify docker certificate path. Defaults to not being set
+     */
+    @Parameter(property = "docker.certPath")
+    private String certificatePath;
+
     @Component
     private MavenProject project;
 
@@ -150,6 +156,9 @@ abstract class AbstractDockerMojo extends AbstractMojo {
         }
         if (serverAddress != null) {
             builder = builder.withServerAddress(serverAddress);
+        }
+        if (certificatePath != null) {
+            builder = builder.withDockerCertPath(certificatePath);
         }
 
         return DockerClientBuilder.getInstance(builder.build()).build();


### PR DESCRIPTION
The latest boot2docker runs the Docker daemon in behind https using self signed certificates. The docker client needs these certificates to be specified for it to connect without SSL errors.