### PR TITLE
Add capability to detect version

### DIFF
--- a/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
+++ b/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
@@ -6,6 +6,8 @@ import com.alexecollins.docker.orchestration.model.BuildFlag;
 import com.alexecollins.docker.util.MavenLogAppender;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.model.Version;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import org.apache.maven.plugin.AbstractMojo;
@@ -126,6 +128,11 @@ abstract class AbstractDockerMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", property = "docker.cleanContainerOnly")
     private boolean cleanContainerOnly;
 
+    /**
+     * Do auto detection on the docker version.
+     */
+    @Parameter(defaultValue = "true", property = "docker.versionAutoDetect")
+    private boolean versionAutoDetect;
 
     @Component
     private MavenProject project;
@@ -215,7 +222,17 @@ abstract class AbstractDockerMojo extends AbstractMojo {
             builder = builder.withDockerCfgPath(cfgPath);
         }
 
-        return DockerClientBuilder.getInstance(builder.build()).build();
+        if (versionAutoDetect) {
+            final DockerClient initialClient = DockerClientBuilder.getInstance(builder.build()).build();
+            final VersionCmd versionCmd = initialClient.versionCmd();
+            final Version version = versionCmd.exec();
+
+            builder = builder.withVersion(version.getApiVersion());
+
+            return DockerClientBuilder.getInstance(builder.build()).build();
+        } else {
+            return DockerClientBuilder.getInstance(builder.build()).build();
+        }
     }
 
 


### PR DESCRIPTION
In order to avoid backward compatibility issues with the docker daemon the
maven plugin can auto-detect the current API version and use workarounds for
api changes (related to alexec/docker-java-orchestration#49)

Will work with docker-java 2.1.2-SNAPSHOT with this PR https://github.com/docker-java/docker-java/pull/335