### PR TITLE
Unit tests to increase code coverage from 33% to 86%

### DIFF
--- a/CODE_COVERAGE.md
+++ b/CODE_COVERAGE.md
@@ -1,0 +1,7 @@
+# Code Coverage Report generation
+
+To generate the code coverage report, execute the following command:
+> mvn clean verify
+
+This will generate code coverage report. In order to view it, open the following file in your browser
+> target/site/cobertura/index.html

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,34 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>cobertura-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <check>
+                        true
+                    </check>
+                    <formats>
+                        <format>html</format>
+                    </formats>
+                    <outputDirectory>${project.build.directory}/site/cobertura</outputDirectory>
+                    <instrumentation>
+                        <ignoreTrivial>true</ignoreTrivial>
+                        <excludes>
+                            <exclude>**/HelpMojo.class</exclude>
+                        </excludes>
+                    </instrumentation>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>cobertura</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.3.1</version>
                 <executions>

--- a/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
+++ b/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
@@ -5,7 +5,7 @@ import com.alexecollins.docker.orchestration.ExcludeFilter;
 import com.alexecollins.docker.orchestration.model.BuildFlag;
 import com.alexecollins.docker.util.MavenLogAppender;
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.model.Version;
 import com.github.dockerjava.core.DockerClientBuilder;

--- a/src/test/java/com/alexecollins/docker/mojo/AbstractDockerMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/AbstractDockerMojoTest.java
@@ -1,16 +1,24 @@
 package com.alexecollins.docker.mojo;
 
 import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.alexecollins.docker.orchestration.model.BuildFlag;
 import com.github.dockerjava.api.DockerClient;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -24,25 +32,71 @@ public class AbstractDockerMojoTest extends MojoTestSupport {
 
     private AbstractDockerMojo dockerMojo;
 
+    private DockerClient dockerClient;
+
     @Before
     public void setUp() throws Exception {
-        // prepare mojo
         dockerMojo = PowerMockito.spy(new AbstractDockerMojo() {
             @Override
             protected void doExecute(DockerOrchestrator orchestrator) throws Exception {
                 // do nothing
             }
         });
+        dockerClient = mock(DockerClient.class);
 
-        DockerClient mockDockerClient = mock(DockerClient.class);
-        DockerOrchestrator mockDockerOrchestrator = mock(DockerOrchestrator.class);
-
-        prepareMojo(dockerMojo, mockDockerClient, mockDockerOrchestrator);
+        prepareMojo(dockerMojo, dockerClient, null);
     }
 
+    @Test
+    public void testExecution() throws Exception {
+        // given
+        ArgumentCaptor<DockerOrchestrator> captor = ArgumentCaptor.forClass(DockerOrchestrator.class);
+
+        // when
+        dockerMojo.execute();
+
+        // then
+        verify(dockerMojo).doExecute(captor.capture());
+        DockerOrchestrator capturedOrchestrator = captor.getValue();
+        assertNotNull(capturedOrchestrator);
+
+        assertEquals(dockerClient, Whitebox.getInternalState(capturedOrchestrator, "docker"));
+
+        Set<BuildFlag> buildFlags = Whitebox.getInternalState(capturedOrchestrator, "buildFlags");
+        assertNotNull(buildFlags);
+        assertFalse(buildFlags.contains(BuildFlag.NO_CACHE));
+        assertFalse(buildFlags.contains(BuildFlag.PULL));
+        assertFalse(buildFlags.contains(BuildFlag.QUIET));
+    }
 
     @Test
-    public void testSkip() throws Exception {
+    public void testExecutionWithFlags() throws Exception {
+        // given
+        Whitebox.setInternalState(dockerMojo, "cache", false);
+        Whitebox.setInternalState(dockerMojo, "quiet", true);
+        Whitebox.setInternalState(dockerMojo, "pull", true);
+
+        ArgumentCaptor<DockerOrchestrator> captor = ArgumentCaptor.forClass(DockerOrchestrator.class);
+
+        // when
+        dockerMojo.execute();
+        
+        // then
+        verify(dockerMojo).doExecute(captor.capture());
+        DockerOrchestrator capturedOrchestrator = captor.getValue();
+        assertNotNull(capturedOrchestrator);
+
+        assertEquals(dockerClient, Whitebox.getInternalState(capturedOrchestrator, "docker"));
+
+        Set<BuildFlag> buildFlags = Whitebox.getInternalState(capturedOrchestrator, "buildFlags");
+        assertNotNull(buildFlags);
+        assertTrue(buildFlags.contains(BuildFlag.NO_CACHE));
+        assertTrue(buildFlags.contains(BuildFlag.PULL));
+        assertTrue(buildFlags.contains(BuildFlag.QUIET));
+    }
+    
+    @Test
+    public void testExecutionWithSkip() throws Exception {
         // given
         Whitebox.setInternalState(dockerMojo, "skip", true);
 

--- a/src/test/java/com/alexecollins/docker/mojo/AbstractDockerMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/AbstractDockerMojoTest.java
@@ -64,6 +64,7 @@ public class AbstractDockerMojoTest extends MojoTestSupport {
 
         Set<BuildFlag> buildFlags = Whitebox.getInternalState(capturedOrchestrator, "buildFlags");
         assertNotNull(buildFlags);
+        assertFalse(buildFlags.contains(BuildFlag.REMOVE_INTERMEDIATE_IMAGES));
         assertFalse(buildFlags.contains(BuildFlag.NO_CACHE));
         assertFalse(buildFlags.contains(BuildFlag.PULL));
         assertFalse(buildFlags.contains(BuildFlag.QUIET));
@@ -72,9 +73,11 @@ public class AbstractDockerMojoTest extends MojoTestSupport {
     @Test
     public void testExecutionWithFlags() throws Exception {
         // given
+        Whitebox.setInternalState(dockerMojo, "removeIntermediateImages", true);
         Whitebox.setInternalState(dockerMojo, "cache", false);
         Whitebox.setInternalState(dockerMojo, "quiet", true);
         Whitebox.setInternalState(dockerMojo, "pull", true);
+
 
         ArgumentCaptor<DockerOrchestrator> captor = ArgumentCaptor.forClass(DockerOrchestrator.class);
 
@@ -90,6 +93,7 @@ public class AbstractDockerMojoTest extends MojoTestSupport {
 
         Set<BuildFlag> buildFlags = Whitebox.getInternalState(capturedOrchestrator, "buildFlags");
         assertNotNull(buildFlags);
+        assertTrue(buildFlags.contains(BuildFlag.REMOVE_INTERMEDIATE_IMAGES));
         assertTrue(buildFlags.contains(BuildFlag.NO_CACHE));
         assertTrue(buildFlags.contains(BuildFlag.PULL));
         assertTrue(buildFlags.contains(BuildFlag.QUIET));

--- a/src/test/java/com/alexecollins/docker/mojo/CopyMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/CopyMojoTest.java
@@ -1,0 +1,57 @@
+package com.alexecollins.docker.mojo;
+
+import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.github.dockerjava.api.DockerClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(CopyMojo.class)
+public class CopyMojoTest extends MojoTestSupport {
+
+    private static final String SOURCE = "source";
+
+    private static final String DEST = "dest";
+
+    private CopyMojo copyMojo;
+
+    private DockerOrchestrator mockDockerOrchestrator;
+
+    @Before
+    public void setUp() throws Exception {
+
+        copyMojo = PowerMockito.spy(new CopyMojo());
+        DockerClient mockDockerClient = mock(DockerClient.class);
+        mockDockerOrchestrator = mock(DockerOrchestrator.class);
+
+        prepareMojo(copyMojo, mockDockerClient, mockDockerOrchestrator);
+        Whitebox.setInternalState(copyMojo, "resource", SOURCE);
+        Whitebox.setInternalState(copyMojo, "dest", DEST);
+    }
+
+    @Test
+    public void testCopy() throws Exception {
+        // when
+        copyMojo.execute();
+
+        // then
+        verify(copyMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).copy(SOURCE, DEST);
+    }
+
+    @Test
+    public void testGetters() {
+        assertEquals(SOURCE, copyMojo.getSource());
+        assertEquals(DEST, copyMojo.getDest());
+    }
+}
+

--- a/src/test/java/com/alexecollins/docker/mojo/DeployMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/DeployMojoTest.java
@@ -1,0 +1,42 @@
+package com.alexecollins.docker.mojo;
+
+import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.github.dockerjava.api.DockerClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(DeployMojo.class)
+public class DeployMojoTest extends MojoTestSupport {
+
+    private DeployMojo deployMojo;
+
+    private DockerOrchestrator mockDockerOrchestrator;
+
+    @Before
+    public void setUp() throws Exception {
+
+        deployMojo = PowerMockito.spy(new DeployMojo());
+        DockerClient mockDockerClient = mock(DockerClient.class);
+        mockDockerOrchestrator = mock(DockerOrchestrator.class);
+
+        prepareMojo(deployMojo, mockDockerClient, mockDockerOrchestrator);
+    }
+
+    @Test
+    public void testDeploy() throws Exception {
+        // when
+        deployMojo.execute();
+
+        // then
+        verify(deployMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).push();
+    }
+}

--- a/src/test/java/com/alexecollins/docker/mojo/MojoTestSupport.java
+++ b/src/test/java/com/alexecollins/docker/mojo/MojoTestSupport.java
@@ -4,18 +4,23 @@ import com.alexecollins.docker.orchestration.DockerOrchestrator;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.model.Version;
+import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.DockerClientConfig;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.reflect.Whitebox;
 
 import java.io.File;
 import java.util.Properties;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
+@PrepareForTest(DockerClientBuilder.class)
 public class MojoTestSupport {
 
     protected static final String PROJECT_GROUP_ID = "id.group";
@@ -57,7 +62,11 @@ public class MojoTestSupport {
             VersionCmd mockVersionCmd = mock(VersionCmd.class);
             Version mockVersion = mock(Version.class);
 
-            PowerMockito.doReturn(mockDockerClient).when(dockerMojo, "dockerClient");
+            DockerClientBuilder mockDockerClientBuilder = mock(DockerClientBuilder.class);
+            when(mockDockerClientBuilder.build()).thenReturn(mockDockerClient);
+
+            mockStatic(DockerClientBuilder.class);
+            when(DockerClientBuilder.getInstance(any(DockerClientConfig.class))).thenReturn(mockDockerClientBuilder);
 
             when(mockDockerClient.versionCmd()).thenReturn(mockVersionCmd);
             when(mockVersionCmd.exec()).thenReturn(mockVersion);
@@ -68,8 +77,8 @@ public class MojoTestSupport {
         if (mockDockerOrchestrator != null) {
             PowerMockito.doReturn(mockDockerOrchestrator)
                     .when(dockerMojo, "dockerOrchestrator",
-                            Mockito.any(Properties.class),
-                            Mockito.any(DockerClient.class)
+                            any(Properties.class),
+                            any(DockerClient.class)
                     );
         }
     }

--- a/src/test/java/com/alexecollins/docker/mojo/MojoTestSupport.java
+++ b/src/test/java/com/alexecollins/docker/mojo/MojoTestSupport.java
@@ -10,6 +10,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.reflect.Whitebox;
 
+import java.io.File;
 import java.util.Properties;
 
 import static org.mockito.Mockito.mock;
@@ -27,9 +28,17 @@ public class MojoTestSupport {
 
     protected static final String PROJECT_DESCRIPTION = "Project Description";
 
-    protected static final String BUILD_DIRECTORY = "/build/directory";
+    protected static final String BUILD_DIR = "/build/dir";
 
     protected static final String BUILD_FINAL_NAME = "buildFinalName";
+
+    protected static final String BASE_DIR = "src";
+
+    protected static final String SRC = "main";
+
+    protected static final String PREFIX = "prefix";
+
+    protected static final String USERNAME = "username";
 
 
     protected void prepareMojo(
@@ -39,6 +48,9 @@ public class MojoTestSupport {
 
         MavenProject mavenProject = createMavenProject();
         Whitebox.setInternalState(dockerMojo, "project", mavenProject);
+        Whitebox.setInternalState(dockerMojo, "prefix", PREFIX);
+        Whitebox.setInternalState(dockerMojo, "src", SRC);
+        Whitebox.setInternalState(dockerMojo, "username", USERNAME);
 
         // prepare docker client
         if (mockDockerClient != null) {
@@ -72,6 +84,8 @@ public class MojoTestSupport {
         mavenProject.setDescription(PROJECT_DESCRIPTION);
         mavenProject.setBuild(createBuild());
 
+        mavenProject.setFile(new File(new File(BASE_DIR), "file"));
+
         return mavenProject;
     }
 
@@ -79,10 +93,9 @@ public class MojoTestSupport {
 
         Build build = new Build();
 
-        build.setDirectory(BUILD_DIRECTORY);
+        build.setDirectory(BUILD_DIR);
         build.setFinalName(BUILD_FINAL_NAME);
 
         return build;
     }
-
 }

--- a/src/test/java/com/alexecollins/docker/mojo/PackageMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/PackageMojoTest.java
@@ -1,0 +1,42 @@
+package com.alexecollins.docker.mojo;
+
+import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.github.dockerjava.api.DockerClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(PackageMojo.class)
+public class PackageMojoTest extends MojoTestSupport {
+
+    private PackageMojo packageMojo;
+
+    private DockerOrchestrator mockDockerOrchestrator;
+
+    @Before
+    public void setUp() throws Exception {
+
+        packageMojo = PowerMockito.spy(new PackageMojo());
+        DockerClient mockDockerClient = mock(DockerClient.class);
+        mockDockerOrchestrator = mock(DockerOrchestrator.class);
+
+        prepareMojo(packageMojo, mockDockerClient, mockDockerOrchestrator);
+    }
+
+    @Test
+    public void testPackage() throws Exception {
+        // when
+        packageMojo.execute();
+
+        // then
+        verify(packageMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).build();
+    }
+}

--- a/src/test/java/com/alexecollins/docker/mojo/SaveMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/SaveMojoTest.java
@@ -1,0 +1,116 @@
+package com.alexecollins.docker.mojo;
+
+import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.alexecollins.docker.orchestration.model.Id;
+import com.github.dockerjava.api.DockerClient;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({SaveMojo.class, FilenameUtils.class})
+public class SaveMojoTest extends MojoTestSupport {
+
+    private static final String SAVE_DIR = "/save/dir";
+
+    private static final String EXTENSION = "ext";
+
+    private static Map<Id, File> SAVED_FILES;
+
+    private SaveMojo saveMojo;
+
+    private DockerOrchestrator mockDockerOrchestrator;
+
+    private File saveDir;
+
+    private MavenProjectHelper mavenProjectHelper;
+
+    @BeforeClass
+    public static void init() {
+        SAVED_FILES = new HashMap<>();
+
+        SAVED_FILES.put(new Id("id1"), new File("/saved/file1.ext"));
+        SAVED_FILES.put(new Id("id2"), new File("/saved/file2.ext"));
+        SAVED_FILES.put(new Id("id3"), new File("/saved/file3.ext"));
+
+        SAVED_FILES = Collections.unmodifiableMap(SAVED_FILES);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+        saveMojo = PowerMockito.spy(new SaveMojo());
+
+        saveDir = new File(SAVE_DIR);
+
+        DockerClient mockDockerClient = mock(DockerClient.class);
+
+        mockDockerOrchestrator = mock(DockerOrchestrator.class);
+        when(mockDockerOrchestrator.save(saveDir, true)).thenReturn(SAVED_FILES);
+
+        prepareMojo(saveMojo, mockDockerClient, mockDockerOrchestrator);
+
+        Whitebox.setInternalState(saveMojo, "saveDir", saveDir);
+        Whitebox.setInternalState(saveMojo, "gzipSave", true);
+
+        mavenProjectHelper = mock(MavenProjectHelper.class);
+        Whitebox.setInternalState(saveMojo, "mavenProjectHelper", mavenProjectHelper);
+    }
+
+    @Test
+    public void testSaveWithAttach() throws Exception {
+        // given
+        Whitebox.setInternalState(saveMojo, "attach", true);
+        PowerMockito.mockStatic(FilenameUtils.class);
+        PowerMockito.when(FilenameUtils.getExtension(anyString())).thenReturn(EXTENSION);
+
+        // when
+        saveMojo.execute();
+
+        // then
+        verify(saveMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).save(saveDir, true);
+
+        for (Id id : SAVED_FILES.keySet()) {
+            verify(mavenProjectHelper).attachArtifact(
+                    saveMojo.getProject(), EXTENSION, id.toString(), SAVED_FILES.get(id)
+            );
+        }
+    }
+
+    @Test
+    public void testSaveWithoutAttach() throws Exception {
+        // when
+        saveMojo.execute();
+
+        // then
+        verify(saveMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).save(saveDir, true);
+        verify(mavenProjectHelper, never()).attachArtifact(
+                any(MavenProject.class), anyString(), anyString(), any(File.class)
+        );
+    }
+
+}

--- a/src/test/java/com/alexecollins/docker/mojo/StartMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/StartMojoTest.java
@@ -1,0 +1,75 @@
+package com.alexecollins.docker.mojo;
+
+import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.github.dockerjava.api.DockerClient;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(StartMojo.class)
+public class StartMojoTest extends MojoTestSupport {
+
+    private static Map<String,String> IP_ADDRESSES;
+
+    private StartMojo startMojo;
+
+    private DockerOrchestrator mockDockerOrchestrator;
+
+    @BeforeClass
+    public static void init() {
+
+        IP_ADDRESSES = new HashMap<>();
+
+        IP_ADDRESSES.put("ip1", "10.10.0.1");
+        IP_ADDRESSES.put("ip2", "10.10.0.2");
+        IP_ADDRESSES.put("ip3", "10.10.0.3");
+        IP_ADDRESSES.put("ip4", "10.10.0.4");
+
+        IP_ADDRESSES = Collections.unmodifiableMap(IP_ADDRESSES);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+
+        startMojo = PowerMockito.spy(new StartMojo());
+        DockerClient mockDockerClient = mock(DockerClient.class);
+
+        mockDockerOrchestrator = mock(DockerOrchestrator.class);
+        doReturn(IP_ADDRESSES).when(mockDockerOrchestrator).getIPAddresses();
+
+        prepareMojo(startMojo, mockDockerClient, mockDockerOrchestrator);
+    }
+
+    @Test
+    public void testStart() throws Exception {
+        // when
+        startMojo.execute();
+
+        // then
+        verify(startMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).start();
+
+        Properties projectProperties = startMojo.getProject().getProperties();
+
+        assertEquals(IP_ADDRESSES.size(), projectProperties.size());
+
+        for (String key : IP_ADDRESSES.keySet()) {
+            assertEquals(IP_ADDRESSES.get(key), projectProperties.getProperty("docker." + key + ".ipAddress"));
+        }
+    }
+}

--- a/src/test/java/com/alexecollins/docker/mojo/StopMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/StopMojoTest.java
@@ -1,0 +1,42 @@
+package com.alexecollins.docker.mojo;
+
+import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.github.dockerjava.api.DockerClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(StopMojo.class)
+public class StopMojoTest extends MojoTestSupport {
+
+    private StopMojo stopMojo;
+
+    private DockerOrchestrator mockDockerOrchestrator;
+
+    @Before
+    public void setUp() throws Exception {
+
+        stopMojo = PowerMockito.spy(new StopMojo());
+        DockerClient mockDockerClient = mock(DockerClient.class);
+        mockDockerOrchestrator = mock(DockerOrchestrator.class);
+
+        prepareMojo(stopMojo, mockDockerClient, mockDockerOrchestrator);
+    }
+
+    @Test
+    public void testStop() throws Exception {
+        // when
+        stopMojo.execute();
+
+        // then
+        verify(stopMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).stop();
+    }
+}

--- a/src/test/java/com/alexecollins/docker/mojo/ValidateMojoTest.java
+++ b/src/test/java/com/alexecollins/docker/mojo/ValidateMojoTest.java
@@ -1,0 +1,42 @@
+package com.alexecollins.docker.mojo;
+
+import com.alexecollins.docker.orchestration.DockerOrchestrator;
+import com.github.dockerjava.api.DockerClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ValidateMojo.class)
+public class ValidateMojoTest extends MojoTestSupport {
+
+    private ValidateMojo validateMojo;
+
+    private DockerOrchestrator mockDockerOrchestrator;
+
+    @Before
+    public void setUp() throws Exception {
+
+        validateMojo = PowerMockito.spy(new ValidateMojo());
+        DockerClient mockDockerClient = mock(DockerClient.class);
+        mockDockerOrchestrator = mock(DockerOrchestrator.class);
+
+        prepareMojo(validateMojo, mockDockerClient, mockDockerOrchestrator);
+    }
+
+    @Test
+    public void testValidate() throws Exception {
+        // when
+        validateMojo.execute();
+
+        // then
+        verify(validateMojo).doExecute(mockDockerOrchestrator);
+        verify(mockDockerOrchestrator).validate();
+    }
+}

--- a/src/test/java/com/alexecollins/docker/util/MavenLogAppenderTest.java
+++ b/src/test/java/com/alexecollins/docker/util/MavenLogAppenderTest.java
@@ -1,0 +1,146 @@
+package com.alexecollins.docker.util;
+
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(PowerMockRunner.class)
+public class MavenLogAppenderTest {
+
+    private static final String ERROR_MESAGE = "error message";
+
+    private static final String WARN_MESAGE = "warn message";
+
+    private static final String INFO_MESAGE = "info message";
+
+    private static final String DEBUG_MESAGE = "debug message";
+
+    private static final String TRACE_MESSAGE = "trace message";
+
+    private static final String ALL_MESSAGE = "all message";
+
+
+    private static Log log;
+
+    private MavenLogAppender mavenLogAppender;
+
+    @Before
+    public void setUp() {
+        log = mock(Log.class);
+        MavenLogAppender.setLog(log);
+
+        mavenLogAppender = new MavenLogAppender();
+    }
+
+    @Test
+    public void testErrorLogLevel() {
+        // given
+        ILoggingEvent event = createLoggingEvent(Level.ERROR, ERROR_MESAGE);
+
+        // when
+        mavenLogAppender.append(event);
+
+        // then
+        verify(log).error(ERROR_MESAGE);
+        verify(log, never()).warn(anyString());
+        verify(log, never()).info(anyString());
+        verify(log, never()).debug(anyString());
+    }
+
+    @Test
+    public void testWarnLogLevel() {
+        // given
+        ILoggingEvent event = createLoggingEvent(Level.WARN, WARN_MESAGE);
+
+        // when
+        mavenLogAppender.append(event);
+
+        // then
+        verify(log, never()).error(anyString());
+        verify(log).warn(WARN_MESAGE);
+        verify(log, never()).info(anyString());
+        verify(log, never()).debug(anyString());
+    }
+
+    @Test
+    public void testInfoLogLevel() {
+        // given
+        ILoggingEvent event = createLoggingEvent(Level.INFO, INFO_MESAGE);
+
+        // when
+        mavenLogAppender.append(event);
+
+        // then
+        verify(log, never()).error(anyString());
+        verify(log, never()).warn(anyString());
+        verify(log).info(INFO_MESAGE);
+        verify(log, never()).debug(anyString());
+    }
+
+    @Test
+    public void testDebugLogLevel() {
+        // given
+        ILoggingEvent event = createLoggingEvent(Level.DEBUG, DEBUG_MESAGE);
+
+        // when
+        mavenLogAppender.append(event);
+
+        // then
+        verify(log, never()).error(anyString());
+        verify(log, never()).warn(anyString());
+        verify(log, never()).info(anyString());
+        verify(log).debug(eq(DEBUG_MESAGE));
+    }
+
+    @Test
+    public void testTraceLogLevel() {
+        // given
+        ILoggingEvent event = createLoggingEvent(Level.TRACE, TRACE_MESSAGE);
+
+        // when
+        mavenLogAppender.append(event);
+
+        // then
+        verify(log, never()).error(anyString());
+        verify(log, never()).warn(anyString());
+        verify(log, never()).info(anyString());
+        verify(log).debug(TRACE_MESSAGE);
+    }
+
+    @Test
+    public void testAllLogLevel() {
+        // given
+        ILoggingEvent event = createLoggingEvent(Level.ALL, ALL_MESSAGE);
+
+        // when
+        mavenLogAppender.append(event);
+
+        // then
+        verify(log, never()).error(anyString());
+        verify(log, never()).warn(anyString());
+        verify(log, never()).info(anyString());
+        verify(log).debug(ALL_MESSAGE);
+    }
+
+    private ILoggingEvent createLoggingEvent(Level level, String message) {
+        ILoggingEvent event = mock(LoggingEvent.class);
+
+        doReturn(level).when(event).getLevel();
+        doReturn(message).when(event).getMessage();
+
+        return event;
+    }
+}

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--suppress XmlUnboundNsPrefix -->
+<configuration debug="false">
+
+    <appender name="MAVEN" class="ch.qos.logback.core.helpers.NOPAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info" additivity="false">
+        <appender-ref ref="MAVEN"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This pull request contains unit tests for whole docker-maven-plugin sources. Code coverage is measured using Cobertura. This pull request increases code coverage of the whole project by 53%. 

The code coverage report can be generated and viewed using the instructions mentioned in CODE_COVERAGE.md

Please note that HelpMojo class was excluded from coverage scope as auto-generated source.

| Metric | Before | After |
| ------------- |:-------------:| -----:|
| Coverage % | 33% | 86% |
| Lines Covered | 45 | 117 |
| Total Lines | 135 | 135 |

Please let me know if you have any questions. 

Alexey Syrtsev
DevFactory - Code Quality Team
