### PR TITLE
 * Fixed description of the config path

### DIFF
--- a/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
+++ b/src/main/java/com/alexecollins/docker/mojo/AbstractDockerMojo.java
@@ -124,7 +124,7 @@ abstract class AbstractDockerMojo extends AbstractMojo {
 
     /**
      * Specify the docker configuration path. Defaults to not being set.
-     * Will look for a file called .dockercfg in the given path for
+     * Will look for a file called .dockercfg (legacy) or a file called config.json in the given path for
      * authentication.
      */
     @Parameter(property = "docker.cfgPath")


### PR DESCRIPTION
Fixed descrption since i updated the docker-java version in https://github.com/alexec/docker-java-orchestration/pull/92 which will fix the issue with the different docker config formats.

After the merge can we please release the docker-java-orchestration together with docker-maven-plugin so we have this available. Thank you